### PR TITLE
Update documentation in examples and more

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,11 @@ We are happy you wish to contribute this project, for that reason we want to boa
 
 Steps that contributor should follow in order to create a pull request
 
-[Fork](https://help.github.com/articles/fork-a-repo/) the [repository](https://github.com/securedeveloper/react-data-export) by clicking the 'Fork' icon in the top-right corner of GitHub
+[Fork](https://help.github.com/articles/fork-a-repo/) the [repository](https://github.com/securedeveloper/react-export-excel) by clicking the 'Fork' icon in the top-right corner of GitHub
 
 Clone the repository in the command line on your PC:
 
-`$ git clone https://github.com/securedeveloper/react-data-export`
+`$ git clone https://github.com/securedeveloper/react-export-excel`
 
 Navigate to the cloned repository in the OS' file manager GUI or on the command line, e.g.
 

--- a/examples/simple_excel_export_01.md
+++ b/examples/simple_excel_export_01.md
@@ -2,7 +2,7 @@
 
 ```javascript
 import React from "react";
-import ReactExport from "react-data-export";
+import ReactExport from "react-export-excel";
 
 const ExcelFile = ReactExport.ExcelFile;
 const ExcelSheet = ReactExport.ExcelFile.ExcelSheet;
@@ -70,5 +70,5 @@ class Download extends React.Component {
 }
 ```
 
-## Output 
+## Output
 ![Simple Excel Export](https://i.imgur.com/6fwdJeo.png)

--- a/examples/simple_excel_export_02.md
+++ b/examples/simple_excel_export_02.md
@@ -1,6 +1,6 @@
 ```javascript
 import React from "react";
-import {ExcelFile, ExcelSheet} from "react-data-export";
+import {ExcelFile, ExcelSheet} from "react-export-excel";
 
 const multiDataSet = [
     {
@@ -40,4 +40,3 @@ class Download extends React.Component {
 
 ## Output
 ![Simple Excel Export with dataset](http://i67.tinypic.com/2jcybeu.jpg)
-

--- a/examples/styled_excel_sheet.md
+++ b/examples/styled_excel_sheet.md
@@ -1,6 +1,6 @@
 ```javascript
 import React, {Component} from 'react';
-import ReactExport from 'react-data-export';
+import ReactExport from 'react-export-excel';
 import './App.css';
 
 const ExcelFile = ReactExport.ExcelFile;

--- a/examples/with_custom_download_element.md
+++ b/examples/with_custom_download_element.md
@@ -1,6 +1,6 @@
 ```javascript
 import React from "react";
-import ReactExport from "react-data-export";
+import ReactExport from "react-export-excel";
 
 const ExcelFile = ReactExport.ExcelFile;
 const ExcelSheet = ReactExport.ExcelFile.ExcelSheet;


### PR DESCRIPTION
**Type:** Bug

**Description:** Could not import ReactExport from 'react-data-export' as shown in example documentation. It only works when I replace 'react-data-export' with 'react-export-excel'.

<!-- Resolves #??? -->