### PR TITLE
Add column header width and style

### DIFF
--- a/dist/ExcelPlugin/utils/DataUtil.js
+++ b/dist/ExcelPlugin/utils/DataUtil.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
     value: true
@@ -7,7 +7,7 @@ exports.excelSheetFromDataSet = exports.excelSheetFromAoA = exports.dateToNumber
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-var _xlsx = require('xlsx');
+var _xlsx = require("xlsx");
 
 var _xlsx2 = _interopRequireDefault(_xlsx);
 
@@ -18,7 +18,7 @@ var strToArrBuffer = function strToArrBuffer(s) {
     var view = new Uint8Array(buf);
 
     for (var i = 0; i != s.length; ++i) {
-        view[i] = s.charCodeAt(i) & 0xFF;
+        view[i] = s.charCodeAt(i) & 0xff;
     }
 
     return buf;
@@ -55,8 +55,8 @@ var excelSheetFromDataSet = function excelSheetFromDataSet(dataSet) {
 
     dataSet.forEach(function (dataSetItem) {
         var columns = dataSetItem.columns;
-        var xSteps = typeof dataSetItem.xSteps === 'number' ? dataSetItem.xSteps : 0;
-        var ySteps = typeof dataSetItem.ySteps === 'number' ? dataSetItem.ySteps : 0;
+        var xSteps = typeof dataSetItem.xSteps === "number" ? dataSetItem.xSteps : 0;
+        var ySteps = typeof dataSetItem.ySteps === "number" ? dataSetItem.ySteps : 0;
         var data = dataSetItem.data;
         if (dataSet === undefined || dataSet.length === 0) {
             return;
@@ -66,9 +66,12 @@ var excelSheetFromDataSet = function excelSheetFromDataSet(dataSet) {
 
         if (columns.length >= 0) {
             columns.forEach(function (col, index) {
-                var cellRef = _xlsx2.default.utils.encode_cell({ c: xSteps + index, r: rowCount });
+                var cellRef = _xlsx2.default.utils.encode_cell({
+                    c: xSteps + index,
+                    r: rowCount
+                });
                 fixRange(range, 0, 0, rowCount, xSteps, ySteps);
-                getHeaderCell(col, cellRef, ws);
+                getCell(col, cellRef, ws);
             });
 
             rowCount += 1;
@@ -84,19 +87,56 @@ var excelSheetFromDataSet = function excelSheetFromDataSet(dataSet) {
     });
 
     if (range.s.c < 10000000) {
-        ws['!ref'] = _xlsx2.default.utils.encode_range(range);
+        ws["!ref"] = _xlsx2.default.utils.encode_range(range);
     }
+
+    // set column width
+    ws["!cols"] = setColumnWidth(dataSet);
 
     return ws;
 };
 
-function getHeaderCell(v, cellRef, ws) {
-    var cell = {};
-    var headerCellStyle = { font: { bold: true } };
-    cell.v = v;
-    cell.t = 's';
-    cell.s = headerCellStyle;
-    ws[cellRef] = cell;
+/**
+ * set column width
+ */
+function setColumnWidth(dataSet) {
+    var columnWidths = [];
+
+    // set colum width
+    if (dataSet) {
+        for (var i = 0; i < dataSet.length; i++) {
+
+            var data = dataSet[i];
+            var columns = data.columns;
+
+            if (columns) {
+                for (var j = 0; j < columns.length; j++) {
+
+                    var column = columns[j];
+
+                    if (column.widthPx) {
+                        columnWidths.push({
+                            wpx: column.widthPx
+                        });
+                        continue;
+                    }
+
+                    if (column.widthCh) {
+                        columnWidths.push({
+                            wpx: column.widthCh
+                        });
+                        continue;
+                    }
+
+                    columnWidths.push({
+                        wpx: 64 // 64px is default column width in excel
+                    });
+                }
+            }
+        }
+    }
+
+    return columnWidths;
 }
 
 function getCell(v, cellRef, ws) {
@@ -104,22 +144,22 @@ function getCell(v, cellRef, ws) {
     if (v === null) {
         return;
     }
-    if (typeof v === 'number') {
+    if (typeof v === "number") {
         cell.v = v;
-        cell.t = 'n';
-    } else if (typeof v === 'boolean') {
+        cell.t = "n";
+    } else if (typeof v === "boolean") {
         cell.v = v;
-        cell.t = 'b';
+        cell.t = "b";
     } else if (v instanceof Date) {
-        cell.t = 'n';
+        cell.t = "n";
         cell.z = _xlsx2.default.SSF._table[14];
         cell.v = dateToNumber(cell.v);
-    } else if ((typeof v === 'undefined' ? 'undefined' : _typeof(v)) === 'object') {
+    } else if ((typeof v === "undefined" ? "undefined" : _typeof(v)) === "object") {
         cell.v = v.value;
         cell.s = v.style;
     } else {
         cell.v = v;
-        cell.t = 's';
+        cell.t = "s";
     }
     ws[cellRef] = cell;
 }
@@ -170,16 +210,16 @@ var excelSheetFromAoA = function excelSheetFromAoA(data) {
             }
 
             var cellRef = _xlsx2.default.utils.encode_cell({ c: C, r: R });
-            if (typeof cell.v === 'number') {
-                cell.t = 'n';
-            } else if (typeof cell.v === 'boolean') {
-                cell.t = 'b';
+            if (typeof cell.v === "number") {
+                cell.t = "n";
+            } else if (typeof cell.v === "boolean") {
+                cell.t = "b";
             } else if (cell.v instanceof Date) {
-                cell.t = 'n';
+                cell.t = "n";
                 cell.z = _xlsx2.default.SSF._table[14];
                 cell.v = dateToNumber(cell.v);
             } else {
-                cell.t = 's';
+                cell.t = "s";
             }
 
             ws[cellRef] = cell;
@@ -187,7 +227,7 @@ var excelSheetFromAoA = function excelSheetFromAoA(data) {
     }
 
     if (range.s.c < 10000000) {
-        ws['!ref'] = _xlsx2.default.utils.encode_range(range);
+        ws["!ref"] = _xlsx2.default.utils.encode_range(range);
     }
 
     return ws;

--- a/examples/simple_excel_export_02.md
+++ b/examples/simple_excel_export_02.md
@@ -3,28 +3,32 @@ import React from "react";
 import {ExcelFile, ExcelSheet} from "react-export-excel";
 
 const multiDataSet = [
-    {
-        columns: ["Name", "Salary", "Sex"],
-        data: [
-            ["Johnson", 30000, "Male"],
-            ["Monika", 355000, "Female"],
-            ["Konstantina", 20000, "Female"],
-            ["John", 250000, "Male"],
-            ["Josef", 450500, "Male"],
-        ]
-    },
-    {
-        xSteps: 1, // Will start putting cell with 1 empty cell on left most
-        ySteps: 5, //will put space of 5 rows,
-        columns: ["Name", "Department"],
-        data: [
-            ["Johnson", "Finance"],
-            ["Monika", "IT"],
-            ["Konstantina", "IT Billing"],
-            ["John", "HR"],
-            ["Josef", "Testing"],
-        ]
-    }
+  {
+    columns: [
+      { value: "Name", widthPx: 50 }, // width in pixels
+      { value: "Salary", widthCh: 20 }, // width in charachters
+      { value: "Sex", widthPx: 60, widthCh: 20 }, // will check for width in pixels first
+    ],
+    data: [
+      ["Johnson", 30000, "Male"],
+      ["Monika", 355000, "Female"],
+      ["Konstantina", 20000, "Female"],
+      ["John", 250000, "Male"],
+      ["Josef", 450500, "Male"],
+    ],
+  },
+  {
+    xSteps: 1, // Will start putting cell with 1 empty cell on left most
+    ySteps: 5, //will put space of 5 rows,
+    columns: ["Name", "Department"],
+    data: [
+      ["Johnson", "Finance"],
+      ["Monika", "IT"],
+      ["Konstantina", "IT Billing"],
+      ["John", "HR"],
+      ["Josef", "Testing"],
+    ],
+  },
 ];
 
 class Download extends React.Component {

--- a/examples/styled_excel_sheet.md
+++ b/examples/styled_excel_sheet.md
@@ -6,42 +6,87 @@ import './App.css';
 const ExcelFile = ReactExport.ExcelFile;
 const ExcelSheet = ReactExport.ExcelFile.ExcelSheet;
 
-const multiDataSet = [
-    {
-        columns: ["Headings", "Text Style", "Colors"],
-        data: [
-            [
-                {value: "H1", style: {font: {sz: "24", bold: true}}},
-                {value: "Bold", style: {font: {bold: true}}},
-                {value: "Red", style: {fill: {patternType: "solid", fgColor: {rgb: "FFFF0000"}}}},
-            ],
-            [
-                {value: "H2", style: {font: {sz: "18", bold: true}}},
-                {value: "underline", style: {font: {underline: true}}},
-                {value: "Blue", style: {fill: {patternType: "solid", fgColor: {rgb: "FF0000FF"}}}},
-            ],
-            [
-                {value: "H3", style: {font: {sz: "14", bold: true}}},
-                {value: "italic", style: {font: {italic: true}}},
-                {value: "Green", style: {fill: {patternType: "solid", fgColor: {rgb: "FF00FF00"}}}},
-            ],
-            [
-                {value: "H4", style: {font: {sz: "12", bold: true}}},
-                {value: "strike", style: {font: {strike: true}}},
-                {value: "Orange", style: {fill: {patternType: "solid", fgColor: {rgb: "FFF86B00"}}}},
-            ],
-            [
-                {value: "H5", style: {font: {sz: "10.5", bold: true}}},
-                {value: "outline", style: {font: {outline: true}}},
-                {value: "Yellow", style: {fill: {patternType: "solid", fgColor: {rgb: "FFFFFF00"}}}},
-            ],
-            [
-                {value: "H6", style: {font: {sz: "7.5", bold: true}}},
-                {value: "shadow", style: {font: {shadow: true}}},
-                {value: "Light Blue", style: {fill: {patternType: "solid", fgColor: {rgb: "FFCCEEFF"}}}}
-            ]
-        ]
-    }
+const styledMultiDataSet = [
+  {
+    columns: [
+      {
+        value: "Headings",
+        widthPx: 160,
+        style: { font: { sz: "24", bold: true } },
+      },
+      {
+        value: "Text Style",
+        widthPx: 180,
+        style: { font: { sz: "24", bold: true } },
+      },
+      {
+        value: "Colors",
+        style: { font: { sz: "24", bold: true } }, // if no width set, default excel column width will be used ( 64px )
+      },
+    ],
+    data: [
+      [
+        { value: "H1", style: { font: { sz: "24", bold: true } } },
+        { value: "Bold", style: { font: { bold: true } } },
+        {
+          value: "Red",
+          style: {
+            fill: { patternType: "solid", fgColor: { rgb: "FFFF0000" } },
+          },
+        },
+      ],
+      [
+        { value: "H2", style: { font: { sz: "18", bold: true } } },
+        { value: "underline", style: { font: { underline: true } } },
+        {
+          value: "Blue",
+          style: {
+            fill: { patternType: "solid", fgColor: { rgb: "FF0000FF" } },
+          },
+        },
+      ],
+      [
+        { value: "H3", style: { font: { sz: "14", bold: true } } },
+        { value: "italic", style: { font: { italic: true } } },
+        {
+          value: "Green",
+          style: {
+            fill: { patternType: "solid", fgColor: { rgb: "FF00FF00" } },
+          },
+        },
+      ],
+      [
+        { value: "H4", style: { font: { sz: "12", bold: true } } },
+        { value: "strike", style: { font: { strike: true } } },
+        {
+          value: "Orange",
+          style: {
+            fill: { patternType: "solid", fgColor: { rgb: "FFF86B00" } },
+          },
+        },
+      ],
+      [
+        { value: "H5", style: { font: { sz: "10.5", bold: true } } },
+        { value: "outline", style: { font: { outline: true } } },
+        {
+          value: "Yellow",
+          style: {
+            fill: { patternType: "solid", fgColor: { rgb: "FFFFFF00" } },
+          },
+        },
+      ],
+      [
+        { value: "H6", style: { font: { sz: "7.5", bold: true } } },
+        { value: "shadow", style: { font: { shadow: true } } },
+        {
+          value: "Light Blue",
+          style: {
+            fill: { patternType: "solid", fgColor: { rgb: "FFCCEEFF" } },
+          },
+        },
+      ],
+    ],
+  },
 ];
 
 class App extends Component {

--- a/src/ExcelPlugin/utils/DataUtil.js
+++ b/src/ExcelPlugin/utils/DataUtil.js
@@ -5,7 +5,7 @@ const strToArrBuffer = (s) => {
     var view = new Uint8Array(buf);
 
     for (var i = 0; i != s.length; ++i) {
-        view[i] = s.charCodeAt(i) & 0xFF;
+        view[i] = s.charCodeAt(i) & 0xff;
     }
 
     return buf;
@@ -37,13 +37,15 @@ const excelSheetFromDataSet = (dataSet) => {
     }
 
     var ws = {};
-    var range = {s: {c: 10000000, r: 10000000}, e: {c: 0, r: 0}};
+    var range = { s: { c: 10000000, r: 10000000 }, e: { c: 0, r: 0 } };
     var rowCount = 0;
 
-    dataSet.forEach(dataSetItem => {
+    dataSet.forEach((dataSetItem) => {
         var columns = dataSetItem.columns;
-        var xSteps = typeof(dataSetItem.xSteps) === 'number' ? dataSetItem.xSteps : 0;
-        var ySteps = typeof(dataSetItem.ySteps) === 'number' ? dataSetItem.ySteps : 0;
+        var xSteps =
+      typeof dataSetItem.xSteps === "number" ? dataSetItem.xSteps : 0;
+        var ySteps =
+      typeof dataSetItem.ySteps === "number" ? dataSetItem.ySteps : 0;
         var data = dataSetItem.data;
         if (dataSet === undefined || dataSet.length === 0) {
             return;
@@ -53,9 +55,12 @@ const excelSheetFromDataSet = (dataSet) => {
 
         if (columns.length >= 0) {
             columns.forEach((col, index) => {
-                var cellRef = XLSX.utils.encode_cell({c: xSteps + index, r: rowCount});
+                var cellRef = XLSX.utils.encode_cell({
+                    c: xSteps + index,
+                    r: rowCount,
+                });
                 fixRange(range, 0, 0, rowCount, xSteps, ySteps);
-                getHeaderCell(col, cellRef, ws);
+                getCell(col, cellRef, ws);
             });
 
             rowCount += 1;
@@ -63,7 +68,7 @@ const excelSheetFromDataSet = (dataSet) => {
 
         for (var R = 0; R != data.length; ++R, rowCount++) {
             for (var C = 0; C != data[R].length; ++C) {
-                var cellRef = XLSX.utils.encode_cell({c: C + xSteps, r: rowCount});
+                var cellRef = XLSX.utils.encode_cell({ c: C + xSteps, r: rowCount });
                 fixRange(range, R, C, rowCount, xSteps, ySteps);
                 getCell(data[R][C], cellRef, ws);
             }
@@ -71,19 +76,57 @@ const excelSheetFromDataSet = (dataSet) => {
     });
 
     if (range.s.c < 10000000) {
-        ws['!ref'] = XLSX.utils.encode_range(range);
+        ws["!ref"] = XLSX.utils.encode_range(range);
     }
+
+    // set column width
+    ws["!cols"] = setColumnWidth(dataSet);
 
     return ws;
 };
 
-function getHeaderCell(v, cellRef, ws) {
-    var cell = {};
-    var headerCellStyle = {font: {bold: true}};
-    cell.v = v;
-    cell.t = 's';
-    cell.s = headerCellStyle;
-    ws[cellRef] = cell;
+/**
+ * set column width
+ */
+function setColumnWidth (dataSet) {
+    let columnWidths = [];
+
+    // set colum width
+    if (dataSet) {
+        for (var i=0; i<dataSet.length; i++) {
+
+            const data = dataSet[i];
+            const columns = data.columns;
+            
+            if (columns) {
+                for (var j=0; j<columns.length; j++) {
+            
+                    const column = columns[j];
+
+                    if (column.widthPx) {
+                        columnWidths.push({
+                            wpx: column.widthPx,
+                        });
+                        continue;
+                    }
+
+                    if (column.widthCh) {
+                        columnWidths.push({
+                            wpx: column.widthCh,
+                        });
+                        continue;
+                    }
+                    
+                    columnWidths.push({
+                        wpx: 64, // 64px is default column width in excel
+                    });
+                }
+            }
+
+        }
+    }
+
+    return columnWidths;
 }
 
 function getCell(v, cellRef, ws) {
@@ -91,22 +134,22 @@ function getCell(v, cellRef, ws) {
     if (v === null) {
         return;
     }
-    if (typeof v === 'number') {
+    if (typeof v === "number") {
         cell.v = v;
-        cell.t = 'n';
-    } else if (typeof v === 'boolean') {
+        cell.t = "n";
+    } else if (typeof v === "boolean") {
         cell.v = v;
-        cell.t = 'b';
+        cell.t = "b";
     } else if (v instanceof Date) {
-        cell.t = 'n';
+        cell.t = "n";
         cell.z = XLSX.SSF._table[14];
         cell.v = dateToNumber(cell.v);
-    } else if (typeof v === 'object') {
+    } else if (typeof v === "object") {
         cell.v = v.value;
         cell.s = v.style;
     } else {
         cell.v = v;
-        cell.t = 's';
+        cell.t = "s";
     }
     ws[cellRef] = cell;
 }
@@ -131,7 +174,7 @@ function fixRange(range, R, C, rowCount, xSteps, ySteps) {
 
 const excelSheetFromAoA = (data) => {
     var ws = {};
-    var range = {s: {c: 10000000, r: 10000000}, e: {c: 0, r: 0}};
+    var range = { s: { c: 10000000, r: 10000000 }, e: { c: 0, r: 0 } };
 
     for (var R = 0; R != data.length; ++R) {
         for (var C = 0; C != data[R].length; ++C) {
@@ -151,22 +194,22 @@ const excelSheetFromAoA = (data) => {
                 range.e.c = C;
             }
 
-            var cell = {v: data[R][C]};
+            var cell = { v: data[R][C] };
             if (cell.v === null) {
                 continue;
             }
 
-            var cellRef = XLSX.utils.encode_cell({c: C, r: R});
-            if (typeof cell.v === 'number') {
-                cell.t = 'n';
-            } else if (typeof cell.v === 'boolean') {
-                cell.t = 'b';
+            var cellRef = XLSX.utils.encode_cell({ c: C, r: R });
+            if (typeof cell.v === "number") {
+                cell.t = "n";
+            } else if (typeof cell.v === "boolean") {
+                cell.t = "b";
             } else if (cell.v instanceof Date) {
-                cell.t = 'n';
+                cell.t = "n";
                 cell.z = XLSX.SSF._table[14];
                 cell.v = dateToNumber(cell.v);
             } else {
-                cell.t = 's';
+                cell.t = "s";
             }
 
             ws[cellRef] = cell;
@@ -174,11 +217,15 @@ const excelSheetFromAoA = (data) => {
     }
 
     if (range.s.c < 10000000) {
-        ws['!ref'] = XLSX.utils.encode_range(range);
+        ws["!ref"] = XLSX.utils.encode_range(range);
     }
 
     return ws;
 };
 
-
-export {strToArrBuffer, dateToNumber, excelSheetFromAoA, excelSheetFromDataSet};
+export {
+    strToArrBuffer,
+    dateToNumber,
+    excelSheetFromAoA,
+    excelSheetFromDataSet,
+};


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/securedeveloper/react-data-export/blob/master/CONTRIBUTING.md

  * If your PR fix an issue don't forget to update the unit test or add a new one
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Update examples whether is required
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature

-->
**Feature:**

The following has been addressed in the PR:

*  Add column ( header ) style
*  Add column width

**Description:**

Add functionality to add column style ( like in data list  ), and add width if needed for the column for export with dataset.
Column width is set in column list ( either in pixels or characters )
If width not set in column list, default excel column width ( 64px ) will be used.
